### PR TITLE
-researchPrerequisites for Turret_60cm.xml set to KarlGerat

### DIFF
--- a/Defs/ThingDefs/Cannons_H/Turret_60cm.xml
+++ b/Defs/ThingDefs/Cannons_H/Turret_60cm.xml
@@ -40,7 +40,7 @@
       <Mass>50000</Mass>
     </statBases>
     <researchPrerequisites>
-      <li>mark1howitzer</li>
+      <li>KarlGerat</li>
     </researchPrerequisites>
     <comps>
       <li Class="CompProperties_Explosive">


### PR DESCRIPTION
Moves the KarlGerat to the proper research